### PR TITLE
Add plan editing, sharing, and PDF download

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,18 @@
             <label for="intensityInput">Intensity (1-10):</label>
             <input type="number" id="intensityInput" min="1" max="10" value="5">
         </div>
-        <button id="addBtn">Add Exercise</button>
+        <div id="controls">
+            <button id="addBtn">Add Exercise</button>
+            <div class="dropdown">
+                <button id="shareBtn">Share This ▾</button>
+                <div id="shareMenu" class="dropdown-content">
+                    <a href="#" id="shareTwitter">Twitter</a>
+                    <a href="#" id="shareFacebook">Facebook</a>
+                    <a href="#" id="shareEmail">Email</a>
+                    <a href="#" id="downloadPdf">Download PDF</a>
+                </div>
+            </div>
+        </div>
 
         <div id="infoSection">
             <h2>Exercise Info</h2>
@@ -44,7 +55,7 @@
             <p><strong>Secondary muscles:</strong> <span id="secondaryMuscles"></span></p>
         </div>
 
-        <h2>Your Plan</h2>
+        <h2>Your Plan <button id="clearBtn">Clear Plan</button></h2>
         <table id="planTable">
             <thead>
                 <tr>
@@ -56,11 +67,13 @@
                     <th>Intensity</th>
                     <th>Description</th>
                     <th>Target Muscles</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody></tbody>
         </table>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -336,6 +336,74 @@ document.getElementById('addBtn').addEventListener('click', () => {
     <td>${intensity}</td>
     <td>${description}</td>
     <td>${muscles}</td>
+    <td class="actions">
+      <button class="edit-row">Edit</button>
+      <button class="delete-row">Delete</button>
+    </td>
   `;
   tableBody.appendChild(row);
+
+  row.querySelector('.delete-row').addEventListener('click', () => {
+    row.remove();
+  });
+
+  row.querySelector('.edit-row').addEventListener('click', () => {
+    selectEl.value = exercise;
+    document.getElementById('setsInput').value = sets;
+    document.getElementById('repsInput').value = reps;
+    document.getElementById('timeInput').value = time;
+    document.getElementById('breakInput').value = brk;
+    document.getElementById('intensityInput').value = intensity;
+    updateInfo();
+    row.remove();
+  });
 });
+
+document.getElementById('clearBtn').addEventListener('click', () => {
+  tableBody.innerHTML = '';
+});
+
+function getPlanText() {
+  let text = 'My Workout Plan:\n';
+  tableBody.querySelectorAll('tr').forEach(row => {
+    const cells = row.querySelectorAll('td');
+    if (cells.length > 0) {
+      text += `${cells[0].textContent} - ${cells[1].textContent} sets x ${cells[2].textContent} reps\n`;
+    }
+  });
+  return text;
+}
+
+const shareBtn = document.getElementById('shareBtn');
+const shareMenu = document.getElementById('shareMenu');
+shareBtn.addEventListener('click', () => {
+  shareMenu.parentElement.classList.toggle('show');
+});
+
+document.getElementById('shareTwitter').addEventListener('click', () => {
+  const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(getPlanText())}`;
+  window.open(url, '_blank');
+});
+
+document.getElementById('shareFacebook').addEventListener('click', () => {
+  const url = `https://www.facebook.com/sharer/sharer.php?u=&quote=${encodeURIComponent(getPlanText())}`;
+  window.open(url, '_blank');
+});
+
+document.getElementById('shareEmail').addEventListener('click', () => {
+  location.href = `mailto:?subject=My Workout Plan&body=${encodeURIComponent(getPlanText())}`;
+});
+
+document.getElementById('downloadPdf').addEventListener('click', () => {
+  const doc = new jspdf.jsPDF();
+  doc.text('My Workout Plan', 10, 10);
+  let y = 20;
+  tableBody.querySelectorAll('tr').forEach(row => {
+    const cells = row.querySelectorAll('td');
+    const line = `${cells[0].textContent} - ${cells[1].textContent} sets x ${cells[2].textContent} reps`;
+    doc.text(line, 10, y);
+    y += 10;
+  });
+  doc.save('workout_plan.pdf');
+});
+

--- a/style.css
+++ b/style.css
@@ -26,6 +26,10 @@ h1, h2 {
     margin-bottom: 20px;
 }
 
+#clearBtn {
+    margin-left: 10px;
+}
+
 .form-group {
     margin-bottom: 15px;
 }
@@ -69,6 +73,46 @@ th, td {
     border: 1px solid #ddd;
     padding: 8px;
     text-align: left;
+}
+
+.actions button {
+    margin-right: 5px;
+}
+
+#controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    right: 0;
+    background-color: #fff;
+    min-width: 150px;
+    box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+
+.dropdown-content a {
+    color: #333;
+    padding: 8px 12px;
+    text-decoration: none;
+    display: block;
+}
+
+.dropdown-content a:hover {
+    background-color: #f1f1f1;
+}
+
+.dropdown.show .dropdown-content {
+    display: block;
 }
 
 th {


### PR DESCRIPTION
## Summary
- add share menu and share/download options
- enable editing and deleting exercises in the plan
- add button to clear entire plan
- style dropdown and controls area
- include jsPDF for PDF downloads

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e3a266b8832b96fe529d941ad0a7